### PR TITLE
Dereference & pass logger to Pusher

### DIFF
--- a/scoutd.go
+++ b/scoutd.go
@@ -142,7 +142,7 @@ func initPusher(agentRunning *sync.Mutex, wg *sync.WaitGroup) {
 	for ; ; time.Sleep(30 * time.Second) {
 		if conn == nil {
 			config.Log.Println("Connecting to Pusher")
-			conn, err = pusher.New("f07eaa39898f3c36c8cf")
+			conn, err = pusher.New("f07eaa39898f3c36c8cf", config.Log)
 			if err != nil {
 				config.Log.Printf("Error connecting to pusher: %s", err)
 			} else {
@@ -193,7 +193,7 @@ func reportLoop(agentRunning *sync.Mutex, wg *sync.WaitGroup) {
 }
 
 func listenForRealtime(commandChannel **pusher.Channel, wg *sync.WaitGroup) {
-	messages := commandChannel.Bind("streamer_command") // a go channel is returned
+	messages := (*commandChannel).Bind("streamer_command") // a go channel is returned
 
 	var rtReadPipe, rtWritePipe *os.File // We'll use these to store the pointers to the current pipes for realtime
 	var cmdOutput []byte
@@ -254,7 +254,7 @@ func listenForRealtime(commandChannel **pusher.Channel, wg *sync.WaitGroup) {
 }
 
 func listenForUpdates(commandChannel **pusher.Channel, agentRunning *sync.Mutex, wg *sync.WaitGroup) {
-	messages := commandChannel.Bind("client_message") // a go channel is returned
+	messages := (*commandChannel).Bind("client_message") // a go channel is returned
 	for {
 		select {
 		case msg := <-messages:

--- a/scoutd/version.go
+++ b/scoutd/version.go
@@ -1,3 +1,3 @@
 package scoutd
 
-const Version = "0.5.39"
+const Version = "0.5.40"


### PR DESCRIPTION
Daemon panics when reading from Pusher socket fails. 

https://github.com/pingdomserver/pusher/pull/1

```
Apr 01 01:24:19 web1.***.com scoutd: panic: EOF
Apr 01 01:24:19 web1.***.com scoutd: goroutine 35 [running]:
Apr 01 01:24:19 web1.***.com scoutd: runtime.panic(0x72f460, 0xc208036020)
Apr 01 01:24:19 web1.***.com scoutd: /opt/go1.3.3/go/src/pkg/runtime/panic.c:279 +0xf5
Apr 01 01:24:19 web1.***.com scoutd: github.com/pingdomserver/pusher.(*Connection).poll(0xc208255860)
Apr 01 01:24:19 web1.***.com scoutd: /opt/scoutd_go_workspace/src/github.com/pingdomserver/pusher/connection.go:54 +0xb5
Apr 01 01:24:19 web1.***.com scoutd: created by github.com/pingdomserver/pusher.New
Apr 01 01:24:19 web1.***.com scoutd: /opt/scoutd_go_workspace/src/github.com/pingdomserver/pusher/connection.go:35 +0x2e2
Apr 01 01:24:19 web1.***.com scoutd: goroutine 16 [semacquire, 31 minutes]:
```